### PR TITLE
Keep regex-delimiters when lexing regex

### DIFF
--- a/parser/src/common/lexer.rs
+++ b/parser/src/common/lexer.rs
@@ -68,7 +68,10 @@ pub mod value {
     pub fn regex<I: Stream + StreamIsPartial + Compare<&'static str> + FindSlice<&'static str>>(
         input: &mut I,
     ) -> PResult<Value<<I as Stream>::Slice>> {
-        delimited_by("^", "$").map(Value::Regex).parse_next(input)
+        delimited_by("^", "$")
+            .take()
+            .map(Value::Regex)
+            .parse_next(input)
     }
 
     /// Tries to parse a number.

--- a/parser/src/config/lexer.rs
+++ b/parser/src/config/lexer.rs
@@ -175,7 +175,7 @@ mod test {
             Token::Identifier("property2"),
             Token::Separator,
             Token::Value(Value::Number("1.2")),
-            Token::Value(Value::Regex("regex")),
+            Token::Value(Value::Regex("^regex$")),
             Token::Comment(" comment "),
             Token::Separator,
             Token::Identifier("identifier"),

--- a/parser/src/config/visual.rs
+++ b/parser/src/config/visual.rs
@@ -642,7 +642,7 @@ mod test {
                     },
                 },
                 legend: AtomLegendConfig {
-                    name: vec![(Regex::new(".*").unwrap(), "$0".to_string())],
+                    name: vec![(Regex::new("^.*$").unwrap(), "$0".to_string())],
                     font: FontConfig {
                         family: "Nice Font".to_string(),
                         size: Fraction::new(14u64, 1u64),
@@ -659,7 +659,7 @@ mod test {
             zone: ZoneConfig {
                 config: vec![
                     (
-                        Regex::new("zone.*").unwrap(),
+                        Regex::new("^zone.*$").unwrap(),
                         ZoneConfigConfig {
                             color: Color {
                                 r: 0,
@@ -678,7 +678,7 @@ mod test {
                         },
                     ),
                     (
-                        Regex::new(".*").unwrap(),
+                        Regex::new("^.*$").unwrap(),
                         ZoneConfigConfig {
                             color: Color {
                                 r: 0,

--- a/parser/src/input/lexer.rs
+++ b/parser/src/input/lexer.rs
@@ -269,7 +269,7 @@ mod test {
             Token::Identifier("instruction"),
             Token::Identifier("argument"),
             Token::Value(Value::String("argument")),
-            Token::Value(Value::Regex("argument")),
+            Token::Value(Value::Regex("^argument$")),
             Token::Separator,
             Token::TimeSymbol(TimeSpec::Absolute),
             Token::Value(Value::Number("0")),


### PR DESCRIPTION
While lexing a regex, the lexer would previously only keep whatever was between the `^`/`$`, which would lead to subsequent uses of that regex also matching on parts of the input strings instead of the whole string, as is expected from that syntax.
This fixes bugs originating in regexes wrongly matching substring, as was discovered in https://github.com/cda-tum/mqt-naviz/issues/57#issuecomment-2622084128.