### PR TITLE
Allow `mqt na` instructions to take position lists

### DIFF
--- a/import/src/mqt/na/convert.rs
+++ b/import/src/mqt/na/convert.rs
@@ -175,9 +175,15 @@ pub fn convert_operation(
         }
         OperationArgs::Local { argument, targets } => targets
             .iter()
-            .map(|target| foo(operation.name, get_id(target, position_cache)?, *argument))
+            .map(|target| {
+                convert_operation_instruction(
+                    operation.name,
+                    get_id(target, position_cache)?,
+                    *argument,
+                )
+            })
             .collect(),
-        OperationArgs::Global(argument) => foo(
+        OperationArgs::Global(argument) => convert_operation_instruction(
             operation.name,
             global_zone_options.get(operation.name)?.to_string(),
             *argument,
@@ -186,7 +192,9 @@ pub fn convert_operation(
     }
 }
 
-fn foo(
+/// Converts a single [OperationArgs::Local] or [OperationArgs::Global] operation
+/// to an instruction.
+fn convert_operation_instruction(
     name: &str,
     target: String,
     argument: Option<Number>,

--- a/import/src/mqt/na/convert.rs
+++ b/import/src/mqt/na/convert.rs
@@ -173,14 +173,16 @@ pub fn convert_operation(
                 })
                 .collect()
         }
-        OperationArgs::Local { argument, target } => {
-            foo(operation.name, get_id(target, position_cache)?, *argument)
-        }
+        OperationArgs::Local { argument, targets } => targets
+            .iter()
+            .map(|target| foo(operation.name, get_id(target, position_cache)?, *argument))
+            .collect(),
         OperationArgs::Global(argument) => foo(
             operation.name,
             global_zone_options.get(operation.name)?.to_string(),
             *argument,
-        ),
+        )
+        .map(|i| [i].into()),
     }
 }
 
@@ -188,8 +190,8 @@ fn foo(
     name: &str,
     target: String,
     argument: Option<Number>,
-) -> Result<Vec<TimedInstruction>, OperationConversionError> {
-    Ok(vec![match name {
+) -> Result<TimedInstruction, OperationConversionError> {
+    Ok(match name {
         "cz" => {
             if argument.is_some() {
                 return Err(OperationConversionError::SuperfluousArgument);
@@ -217,7 +219,7 @@ fn foo(
             }
         }
         _ => return Err(OperationConversionError::InvalidName),
-    }])
+    })
 }
 
 impl From<Position> for (Fraction, Fraction) {

--- a/import/src/mqt/na/convert.rs
+++ b/import/src/mqt/na/convert.rs
@@ -284,11 +284,15 @@ fn assert_same_lengths<A, B>(a: &[A], b: &[B]) -> Result<(), OperationConversion
 
 #[cfg(test)]
 mod test {
-    use naviz_parser::input::concrete::Instructions;
+    use std::sync::Arc;
+
+    use naviz_parser::input::concrete::{
+        InstructionGroup, Instructions, SetupInstruction, TimedInstruction,
+    };
 
     use crate::mqt::na::{
         convert::{ConvertOptions, GlobalZoneNames},
-        format::parse,
+        format::{parse, Operation, OperationArgs, Position},
     };
 
     use super::convert;
@@ -324,6 +328,112 @@ mod test {
         assert_eq!(
             converted, expected,
             "Conversion did not produce expected result"
+        );
+    }
+
+    #[test]
+    fn instruction_position_list() {
+        let atoms: Arc<[_]> = [
+            Position {
+                x: 9.into(),
+                y: 8.into(),
+            },
+            Position {
+                x: 1.into(),
+                y: 2.into(),
+            },
+            Position {
+                x: 8.into(),
+                y: 8.into(),
+            },
+            Position {
+                x: 0.into(),
+                y: 0.into(),
+            },
+        ]
+        .into();
+
+        let input = [
+            Operation {
+                name: "init",
+                args: OperationArgs::Init(atoms.clone()),
+            },
+            Operation {
+                name: "ry",
+                args: OperationArgs::Local {
+                    argument: Some(57.into()),
+                    targets: atoms,
+                },
+            },
+        ]
+        .into();
+
+        let converted = convert(
+            &input,
+            ConvertOptions {
+                atom_prefix: "atom".into(),
+                global_zones: GlobalZoneNames {
+                    cz: "global_cz".into(),
+                    ry: "global_ry".into(),
+                    rz: "global_rz".into(),
+                },
+            },
+        )
+        .expect("Failed to convert");
+
+        let expected = Instructions {
+            setup: vec![
+                SetupInstruction::Atom {
+                    position: (9.into(), 8.into()),
+                    id: "atom0".to_string(),
+                },
+                SetupInstruction::Atom {
+                    position: (1.into(), 2.into()),
+                    id: "atom1".to_string(),
+                },
+                SetupInstruction::Atom {
+                    position: (8.into(), 8.into()),
+                    id: "atom2".to_string(),
+                },
+                SetupInstruction::Atom {
+                    position: (0.into(), 0.into()),
+                    id: "atom3".to_string(),
+                },
+            ],
+            instructions: vec![(
+                0.into(),
+                vec![(
+                    false,
+                    0.into(),
+                    InstructionGroup {
+                        variable: false,
+                        instructions: vec![
+                            TimedInstruction::Ry {
+                                value: 57.into(),
+                                id: "atom0".to_string(),
+                            },
+                            TimedInstruction::Ry {
+                                value: 57.into(),
+                                id: "atom1".to_string(),
+                            },
+                            TimedInstruction::Ry {
+                                value: 57.into(),
+                                id: "atom2".to_string(),
+                            },
+                            TimedInstruction::Ry {
+                                value: 57.into(),
+                                id: "atom3".to_string(),
+                            },
+                        ],
+                    },
+                )],
+            )],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            converted, expected,
+            "Instruction with position list incorrectly converted."
         );
     }
 }

--- a/import/src/mqt/na/format.rs
+++ b/import/src/mqt/na/format.rs
@@ -41,7 +41,7 @@ pub enum OperationArgs {
     /// `<name>(<number>) at <positions>` / `<name> at <positions>`
     Local {
         argument: Option<Number>,
-        target: Position,
+        targets: PositionList,
     },
     /// `<name>(<number>)` / `<name>`
     Global(Option<Number>),
@@ -59,11 +59,11 @@ impl Display for OperationArgs {
                     SeparatedDisplay::comma(to)
                 )
             }
-            Self::Local { argument, target } => {
+            Self::Local { argument, targets } => {
                 if let Some(argument) = argument {
                     write!(f, "({})", Decimal::from_fraction(*argument))?;
                 }
-                write!(f, " at {target}")
+                write!(f, " at {}", SeparatedDisplay::comma(targets))
             }
             Self::Global(argument) => {
                 if let Some(argument) = argument {
@@ -221,7 +221,7 @@ pub mod operation {
     };
 
     use super::{
-        parts::{number, position, position_list},
+        parts::{number, position_list},
         Number, Operation, OperationArgs,
     };
 
@@ -307,12 +307,12 @@ pub mod operation {
                 multispace0,
             )),
             terminated("at", multispace0),
-            terminated(position, multispace0),
+            terminated(position_list, multispace0),
             ";",
         )
-            .map(|(name, argument, _, target, _)| Operation {
+            .map(|(name, argument, _, targets, _)| Operation {
                 name,
-                args: OperationArgs::Local { argument, target },
+                args: OperationArgs::Local { argument, targets },
             })
             .parse_next(input)
     }

--- a/import/src/mqt/na/format.rs
+++ b/import/src/mqt/na/format.rs
@@ -370,7 +370,10 @@ pub mod operation {
 
 #[cfg(test)]
 mod test {
-    use crate::separated_display::SeparatedDisplay;
+    use crate::{
+        mqt::na::format::{Operation, OperationArgs, Position},
+        separated_display::SeparatedDisplay,
+    };
 
     use super::parse;
 
@@ -394,6 +397,83 @@ mod test {
         assert_eq!(
             parsed, parsed_again,
             "Round-Trip failed to produce same deserialized result"
+        );
+    }
+
+    #[test]
+    fn instruction_position_list_parse() {
+        let input = "ry(42) at (0, 0), (1, 1), (2, 2), (3, 3);";
+
+        let parsed = parse(input).expect("Failed to parse!");
+
+        let expected = [Operation {
+            name: "ry",
+            args: OperationArgs::Local {
+                argument: Some(42.into()),
+                targets: [
+                    Position {
+                        x: 0.into(),
+                        y: 0.into(),
+                    },
+                    Position {
+                        x: 1.into(),
+                        y: 1.into(),
+                    },
+                    Position {
+                        x: 2.into(),
+                        y: 2.into(),
+                    },
+                    Position {
+                        x: 3.into(),
+                        y: 3.into(),
+                    },
+                ]
+                .into(),
+            },
+        }]
+        .into();
+
+        assert_eq!(
+            parsed, expected,
+            "Wrongly parsed instruction with position list"
+        );
+    }
+
+    #[test]
+    fn instruction_position_list_stringify() {
+        let input = Operation {
+            name: "ry",
+            args: OperationArgs::Local {
+                argument: Some(1337.into()),
+                targets: [
+                    Position {
+                        x: 4.into(),
+                        y: 4.into(),
+                    },
+                    Position {
+                        x: 3.into(),
+                        y: 3.into(),
+                    },
+                    Position {
+                        x: 2.into(),
+                        y: 2.into(),
+                    },
+                    Position {
+                        x: 1.into(),
+                        y: 1.into(),
+                    },
+                ]
+                .into(),
+            },
+        };
+
+        let exported = input.to_string();
+
+        let expected = "ry(1337) at (4, 4), (3, 3), (2, 2), (1, 1);";
+
+        assert_eq!(
+            exported, expected,
+            "Wrongly stringified instruction with position list"
         );
     }
 }


### PR DESCRIPTION
Global/Local instructions were previously only allowed to take single positions, even though the `mqt na` format allows multiple positions to be defined there.
This PR changes the respective parser to allow for position lists in this location and updates the converter to correctly convert these.

Closes #59.