### PR TITLE
Don't try to load instructions from pastes into text inputs

### DIFF
--- a/gui/src/menu.rs
+++ b/gui/src/menu.rs
@@ -240,6 +240,14 @@ impl MenuBar {
     /// If text was pasted,
     /// will load that text as instructions.
     fn handle_clipboard(&mut self, ctx: &egui::Context) {
+        if ctx.wants_keyboard_input() {
+            // some widgets is listening for keyboard input,
+            // therefore it also consumes paste events.
+            // When something is pasted, it should only go to that widget
+            // and not also try to load as instructions.
+            return;
+        }
+
         ctx.input_mut(|i| {
             i.events.retain_mut(|e| {
                 if let egui::Event::Paste(text) = e {


### PR DESCRIPTION
Currently, when the user is pasting text into a text-input, naviz also tries to load the contents of the clipboard as instructions.
This change only loads the clipboard content as instructions when no text-input is currently focused.