### PR TITLE
Allow sets as targets for operations

### DIFF
--- a/doc/FileFormat.md
+++ b/doc/FileFormat.md
@@ -10,6 +10,7 @@
 | `color`                | Hex-color in `#RRGGBBAA` format; alpha is optional           | `#1eb69dcc`, `#ac52f6`            |
 | `string`               | A string; Must be enclosed in double-quotes                  | `"Hello World!"`, `"Some string"` |
 | `tuple(<a>, <b>, ...)` | A tuple; element-types are specified in parentheses          | `(5, 2)`                          |
+| `set(<type>)`          | A set; element-type is specified in parentheses              | `{ atom0, atom1 }`                |
 | `regex`                | A regex; Must be enclosed in `^`, `$`                        | `^atom.*$`, `^Foo:Bar$`           |
 | `boolean`              | A boolean (`true`/`false`) value                             | `true`, `false`                   |
 
@@ -18,6 +19,7 @@
 | Alias      | Type                    | Description                                                                     |
 | ---------- | ----------------------- | ------------------------------------------------------------------------------- |
 | `position` | `tuple(number, number)` | A position                                                                      |
+| `target`   | `id \| set(target)`     | A target (i.e., a zone, an atom, or a set containing multiple targets)          |
 | `time`     | `number`                | A time; can also be one of the [relative times](#automatic-time--relative-time) |
 
 ## Machine Configuration
@@ -380,26 +382,26 @@ An atom can be moved to a new position using the `move`-command.
 
 #### `rz`-operation
 
-The `rz`-operation can be applied to a zone or atom using the `rz`-command.
+The `rz`-operation can be applied to a target using the `rz`-command.
 
 ```
-@<time> rz <number> <id>
+@<time> rz <number> <target>
 ```
 
 #### `ry`-operation
 
-The `ry`-operation can be applied to a zone or atom using the `ry`-command.
+The `ry`-operation can be applied to a target using the `ry`-command.
 
 ```
-@<time> ry <number> <id>
+@<time> ry <number> <target>
 ```
 
 #### `cz`-operation
 
-The `cz`-operation can be applied to a zone or atom using the `cz`-command.
+The `cz`-operation can be applied to a target using the `cz`-command.
 
 ```
-@<time> cz <id>
+@<time> cz <target>
 ```
 
 ### Syntactic Sugar

--- a/parser/src/common/lexer.rs
+++ b/parser/src/common/lexer.rs
@@ -178,6 +178,10 @@ pub enum GenericToken<T> {
     TupleOpen,
     /// Closing-symbol for a tuple
     TupleClose,
+    // Opening-symbol for a set of values
+    SetOpen,
+    // Closing-symbol for a set of values
+    SetClose,
     /// A separator between elements (e.g., in tuples)
     ElementSeparator,
 }
@@ -302,6 +306,30 @@ pub mod token {
         GenericToken<I::Slice>: Into<Tok>,
     {
         ")".map(|_| GenericToken::TupleClose)
+            .output_into()
+            .parse_next(input)
+    }
+
+    /// Tries to parse a [GenericToken::SetOpen].
+    pub fn set_open<Tok, I: Stream + StreamIsPartial + Compare<&'static str>>(
+        input: &mut I,
+    ) -> PResult<Tok>
+    where
+        GenericToken<I::Slice>: Into<Tok>,
+    {
+        "{".map(|_| GenericToken::SetOpen)
+            .output_into()
+            .parse_next(input)
+    }
+
+    /// Tries to parse a [GenericToken::SetClose].
+    pub fn set_close<Tok, I: Stream + StreamIsPartial + Compare<&'static str>>(
+        input: &mut I,
+    ) -> PResult<Tok>
+    where
+        GenericToken<I::Slice>: Into<Tok>,
+    {
+        "}".map(|_| GenericToken::SetClose)
             .output_into()
             .parse_next(input)
     }

--- a/parser/src/common/parser.rs
+++ b/parser/src/common/parser.rs
@@ -58,6 +58,8 @@ impl PartialEq for Value {
             (Value::Boolean(a), Value::Boolean(b)) => a == b,
             (Value::Color(a), Value::Color(b)) => a == b,
             (Value::Identifier(a), Value::Identifier(b)) => a == b,
+            (Value::Set(a), Value::Set(b)) => a == b,
+            (Value::Tuple(a), Value::Tuple(b)) => a == b,
             _ => false,
         }
     }

--- a/parser/src/common/parser.rs
+++ b/parser/src/common/parser.rs
@@ -255,3 +255,37 @@ pub mod token {
             .parse_next(input)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::Value;
+
+    #[test]
+    fn set_flatten() {
+        let input = Value::Set(vec![
+            Value::Identifier("i1".to_string()),
+            Value::Set(vec![Value::Identifier("i2".to_string())]),
+            Value::Set(vec![
+                Value::Identifier("i3".to_string()),
+                Value::Set(vec![
+                    Value::Identifier("i4".to_string()),
+                    Value::Set(vec![Value::Identifier("i5".to_string())]),
+                ]),
+            ]),
+        ]);
+
+        let expected = vec![
+            Value::Identifier("i1".to_string()),
+            Value::Identifier("i2".to_string()),
+            Value::Identifier("i3".to_string()),
+            Value::Identifier("i4".to_string()),
+            Value::Identifier("i5".to_string()),
+        ];
+
+        assert_eq!(
+            input.flatten_sets().collect::<Vec<_>>(),
+            expected,
+            "Set was incorrectly flattened"
+        );
+    }
+}

--- a/parser/src/config/generic.rs
+++ b/parser/src/config/generic.rs
@@ -28,6 +28,7 @@ pub struct Maps {
     pub boolean: HashMap<bool, Value>,
     pub color: HashMap<Color, Value>,
     pub tuple: Vec<(Vec<Value>, Value)>,
+    pub set: Vec<(Vec<Value>, Value)>,
 }
 
 /// A [ConfigItem] representing either a [Value][ConfigItem::Value], a [Struct][ConfigItem::Struct],
@@ -66,6 +67,10 @@ impl Config {
                 parser::Value::Color(c) => maps.color.insert(c, value).map(ConfigItem::Value),
                 parser::Value::Tuple(t) => {
                     maps.tuple.push((t, value));
+                    None
+                }
+                parser::Value::Set(s) => {
+                    maps.set.push((s, value));
                     None
                 }
             },

--- a/parser/src/config/parser.rs
+++ b/parser/src/config/parser.rs
@@ -54,9 +54,9 @@ pub fn property<S: TryIntoValue + Clone + Debug + PartialEq>(
     input: &mut &[Token<S>],
 ) -> PResult<ConfigItem> {
     (
-        terminated(value_or_identifier_or_tuple, ignore_comments),
+        terminated(any_value, ignore_comments),
         terminated(separator, ignore_comments),
-        value_or_identifier_or_tuple,
+        any_value,
     )
         .map(|(k, _, v)| ConfigItem::Property(k, v))
         .parse_next(input)
@@ -82,7 +82,7 @@ pub fn named_block<S: TryIntoValue + Clone + Debug + PartialEq>(
 ) -> PResult<ConfigItem> {
     (
         terminated(identifier, ignore_comments),
-        terminated(value_or_identifier_or_tuple, ignore_comments),
+        terminated(any_value, ignore_comments),
         terminated(block_open, ignore_comments),
         terminated(config, ignore_comments),
         block_close,
@@ -99,14 +99,14 @@ pub mod token {
     // Re-export the common token-parsers
     pub use common::parser::token::*;
 
-    /// Try to parse a single [Token::BlockOpen].
+    /// Try to parse a single [Token::BlockOrSetOpen] for opening a block.
     pub fn block_open<S: Clone + Debug + PartialEq>(input: &mut &[Token<S>]) -> PResult<()> {
-        one_of([Token::BlockOpen]).void().parse_next(input)
+        one_of([Token::BlockOrSetOpen]).void().parse_next(input)
     }
 
-    /// Try to parse a single [Token::BlockClose].
+    /// Try to parse a single [Token::BlockOrSetClose] for closing a block.
     pub fn block_close<S: Clone + Debug + PartialEq>(input: &mut &[Token<S>]) -> PResult<()> {
-        one_of([Token::BlockClose]).void().parse_next(input)
+        one_of([Token::BlockOrSetClose]).void().parse_next(input)
     }
 
     /// Try to parse a single [Token::Separator].
@@ -170,19 +170,19 @@ mod test {
             Token::Identifier("identifier"),
             Token::Comment(" other comment"),
             Token::Identifier("block"),
-            Token::BlockOpen,
+            Token::BlockOrSetOpen,
             Token::Identifier("named_block"),
             Token::Value(lexer::Value::String("name")),
-            Token::BlockOpen,
+            Token::BlockOrSetOpen,
             Token::Identifier("prop"),
             Token::Separator,
             Token::Value(lexer::Value::Color("c01032")),
             Token::Value(lexer::Value::Number("42")),
             Token::Separator,
             Token::Value(lexer::Value::Boolean("true")),
-            Token::BlockClose,
+            Token::BlockOrSetClose,
             Token::Comment(" }"),
-            Token::BlockClose,
+            Token::BlockOrSetClose,
         ];
 
         let expected = vec![

--- a/parser/src/input/lexer.rs
+++ b/parser/src/input/lexer.rs
@@ -331,4 +331,35 @@ mod test {
 
         assert_eq!(actual, expected);
     }
+
+    #[test]
+    fn identifier_set() {
+        let input = r#"
+        @0 timed_instruction { t1, t2, { t3 }, { t4 }}
+        "#;
+
+        let expected = vec![
+            Token::TimeSymbol(TimeSpec::Absolute),
+            Token::Value(Value::Number("0")),
+            Token::Identifier("timed_instruction"),
+            Token::SetOpen,
+            Token::Identifier("t1"),
+            Token::ElementSeparator,
+            Token::Identifier("t2"),
+            Token::ElementSeparator,
+            Token::SetOpen,
+            Token::Identifier("t3"),
+            Token::SetClose,
+            Token::ElementSeparator,
+            Token::SetOpen,
+            Token::Identifier("t4"),
+            Token::SetClose,
+            Token::SetClose,
+            Token::Separator,
+        ];
+
+        let actual = lex(input).expect("Failed to lex");
+
+        assert_eq!(actual, expected);
+    }
 }

--- a/parser/src/input/lexer.rs
+++ b/parser/src/input/lexer.rs
@@ -19,7 +19,7 @@ pub enum TimeSpec {
     Relative { from_start: bool, positive: bool },
 }
 
-/// A token of the config format
+/// A token of the input format
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Token<T> {
     /// An identifier
@@ -39,6 +39,10 @@ pub enum Token<T> {
     },
     /// Closing-symbol for a group
     GroupClose,
+    // Opening-symbol for a set of values
+    SetOpen,
+    // Closing-symbol for a set of values
+    SetClose,
     /// A separator between elements (e.g., in tuples)
     ElementSeparator,
     /// The symbol to denote the starting-time
@@ -57,6 +61,8 @@ impl<T> From<GenericToken<T>> for Token<T> {
             GenericToken::Comment(c) => Self::Comment(c),
             GenericToken::TupleOpen => Self::TupleOpen,
             GenericToken::TupleClose => Self::TupleClose,
+            GenericToken::SetOpen => Self::SetOpen,
+            GenericToken::SetClose => Self::SetClose,
             GenericToken::ElementSeparator => Self::ElementSeparator,
         }
     }
@@ -70,6 +76,8 @@ impl<T> From<Token<T>> for Option<GenericToken<T>> {
             Token::Comment(c) => Some(GenericToken::Comment(c)),
             Token::TupleOpen => Some(GenericToken::TupleOpen),
             Token::TupleClose => Some(GenericToken::TupleClose),
+            Token::SetOpen => Some(GenericToken::SetOpen),
+            Token::SetClose => Some(GenericToken::SetClose),
             Token::ElementSeparator => Some(GenericToken::ElementSeparator),
             _ => None,
         }
@@ -227,6 +235,8 @@ pub mod token {
             tuple_close,
             group_open,
             group_close,
+            set_open,
+            set_close,
             element_separator,
             time_symbol,
             directive,

--- a/parser/src/input/parser.rs
+++ b/parser/src/input/parser.rs
@@ -83,10 +83,7 @@ pub fn instruction<S: TryIntoValue + Clone + Debug + PartialEq>(
     (
         terminated(opt(time), ignore_comments),
         terminated(identifier, ignore_comments),
-        repeat(
-            0..,
-            terminated(value_or_identifier_or_tuple, ignore_comments),
-        ),
+        repeat(0.., terminated(any_value, ignore_comments)),
         separator,
     )
         .map(|(time, name, args, _)| InstructionOrDirective::Instruction { time, name, args })
@@ -99,10 +96,7 @@ pub fn directive<S: TryIntoValue + Clone + Debug + PartialEq>(
 ) -> PResult<InstructionOrDirective> {
     (
         terminated(token::directive, ignore_comments),
-        repeat(
-            0..,
-            terminated(value_or_identifier_or_tuple, ignore_comments),
-        ),
+        repeat(0.., terminated(any_value, ignore_comments)),
         separator,
     )
         .map(|(name, args, _)| InstructionOrDirective::Directive { name, args })
@@ -127,10 +121,7 @@ pub fn grouped_time<S: TryIntoValue + Clone + Debug + PartialEq>(
     let grouped_instruction = terminated(
         (
             terminated(identifier, ignore_comments),
-            repeat(
-                0..,
-                terminated(value_or_identifier_or_tuple, ignore_comments),
-            ),
+            repeat(0.., terminated(any_value, ignore_comments)),
         ),
         separator,
     );
@@ -162,10 +153,7 @@ pub fn grouped_instruction<S: TryIntoValue + Clone + Debug + PartialEq>(
     input: &mut &[Token<S>],
 ) -> PResult<InstructionOrDirective> {
     let grouped_value = terminated(
-        repeat(
-            0..,
-            terminated(value_or_identifier_or_tuple, ignore_comments),
-        ),
+        repeat(0.., terminated(any_value, ignore_comments)),
         separator,
     );
 


### PR DESCRIPTION
Instead of having to create a new zone when wanting to target a specific set of atoms (which may not always be possible), a set of targets can be entered as a target for an operation.
Targets may be nested arbitrarily deep.

```
@+ cz { atom0, zome0, { atom1, atom2, { zone2 } } }
```

The difference between set-targets and grouped instructions is that grouped instructions decompose to multiple instructions executing at the same time while set-targets are a single instruction that acts on a larger target-group.
In particular, the following two are different (assuming `atom0` and `atom1` are in interaction-distance):
```
// Will not visualize a `cz`-gate between the atoms,
// as each of the two instructions only target one atom each,
// therefore no partner is found.
@+ cz [
    atom0
    atom1
]

// Will visualize a `cz`-gate between the atoms,
// as this describes a single instruction targeting both atoms,
// so a partner can be found.
@+ cz { atom0, atom1 }
```

Closes #65.