### PR TITLE
Set `yuv420p` as pixel format

### DIFF
--- a/video/src/lib.rs
+++ b/video/src/lib.rs
@@ -150,6 +150,11 @@ impl VideoExport {
                 format!("{}/1", self.fps).as_str(),
                 "-i",
                 "-",
+                // Set chroma subsampling for some video players
+                // See https://trac.ffmpeg.org/wiki/Encode/H.264#Encodingfordumbplayers
+                // Should be ignored on formats that don't support it
+                "-vf",
+                "format=yuv420p",
                 "-y",
             ])
             .arg(target)


### PR DESCRIPTION
Needed for some video players to play the video (see [ffmpeg docs](https://trac.ffmpeg.org/wiki/Encode/H.264#Encodingfordumbplayers)).

In the future this along with more options could be configurable (tracked in #92).

Closes #71.