### PR TITLE
Improve playback progress UX

### DIFF
--- a/gui/src/animator_adapter.rs
+++ b/gui/src/animator_adapter.rs
@@ -99,7 +99,11 @@ impl AnimatorAdapter {
             let animator = Animator::new(machine.clone(), visual.clone(), instructions.clone());
             self.update_full = true;
             if reset_time || self.animator.is_none() {
-                self.progress_bar = ProgressBar::new(animator.duration().try_into().unwrap());
+                // Recreate progress bar while keeping the old speed
+                self.progress_bar = ProgressBar::new_with_speed(
+                    animator.duration().try_into().unwrap(),
+                    self.progress_bar.get_speed(),
+                );
             }
             self.animator = Some(animator);
         }

--- a/gui/src/progress_bar.rs
+++ b/gui/src/progress_bar.rs
@@ -59,6 +59,11 @@ impl ProgressBar {
     fn update_time(&mut self, delta: f32) {
         if !self.paused {
             self.animation_time += self.speed * delta as f64;
+
+            if self.animation_time >= self.duration {
+                // pause on end
+                self.paused = true;
+            }
         }
     }
 

--- a/gui/src/progress_bar.rs
+++ b/gui/src/progress_bar.rs
@@ -47,12 +47,22 @@ impl Default for ProgressBar {
 impl ProgressBar {
     /// Creates a new progress-bar with the specified `duration`
     pub fn new(duration: f64) -> Self {
+        Self::new_with_speed(duration, 1.)
+    }
+
+    /// Creates a new progress-bar with the specified `duration` and `speed`
+    pub fn new_with_speed(duration: f64, speed: f64) -> Self {
         Self {
             animation_time: 0.,
-            speed: 1.,
+            speed,
             duration,
             paused: false,
         }
+    }
+
+    /// Gets the currently set speed
+    pub fn get_speed(&self) -> f64 {
+        self.speed
     }
 
     /// Updates the `animation_time` respecting `paused` and `speed`.

--- a/gui/src/progress_bar.rs
+++ b/gui/src/progress_bar.rs
@@ -12,6 +12,8 @@ const SPEED_WIDTH: f32 = BAR_HEIGHT * 2.;
 const PLAY_ICON: &str = "\u{25B6}";
 /// Pause icon (unicode)
 const PAUSE_ICON: &str = "\u{23F8}";
+/// Replay icon (unicode)
+const REPLAY_ICON: &str = "\u{27F2}";
 
 /// Maximum speed
 const MAX_SPEED: f64 = 5.;
@@ -70,21 +72,35 @@ impl ProgressBar {
         if !self.paused {
             self.animation_time += self.speed * delta as f64;
 
-            if self.animation_time >= self.duration {
+            if self.is_end() {
                 // pause on end
                 self.paused = true;
             }
         }
     }
 
+    /// Returns `true` when the playback has reached the end
+    fn is_end(&self) -> bool {
+        self.animation_time >= self.duration
+    }
+
     /// Draws the play/pause button
     fn draw_pause(&mut self, ui: &mut Ui) {
-        let icon = if self.paused { PLAY_ICON } else { PAUSE_ICON };
+        let icon = match (self.paused, self.is_end()) {
+            (true, false) => PLAY_ICON,
+            (true, true) => REPLAY_ICON,
+            (false, _) => PAUSE_ICON,
+        };
         if ui
             .add_sized([PLAY_PAUSE_WIDTH, BAR_HEIGHT], Button::new(icon))
             .clicked()
         {
             self.paused = !self.paused;
+
+            if self.is_end() {
+                // replay when pressing play on end
+                self.animation_time = 0.;
+            }
         }
     }
 


### PR DESCRIPTION
Includes small improvements to the UX of the playback progress:
- Closes #87
  - Pauses the visualization at the end
  - Keeps the currently set playback speed when opening a new visualization
- Closes #83
  - Changes the play-button to a replay-button at the end of the visualization