### PR TITLE
Fix panic with empty buffers after updating `wgpu` in `5046c46`

### DIFF
--- a/renderer/src/component.rs
+++ b/renderer/src/component.rs
@@ -191,6 +191,10 @@ impl<Spec: bytemuck::NoUninit> Component<Spec> {
 
     /// Draws this component
     pub fn draw(&self, render_pass: &mut RenderPass<'_>) {
+        if self.instance_count == 0 {
+            // nothing to render
+            return;
+        }
         render_pass.set_pipeline(&self.render_pipeline);
         render_pass.set_vertex_buffer(0, self.instance_buffer.slice(..));
         render_pass.set_bind_group(2, &self.bind_group, &[]);


### PR DESCRIPTION
## Description

It seems the updated version of `wgpu` in 5046c46 now panics when trying to draw an empty buffer.
This fix will skip drawing empty components (with empty buffers).

Fixes #104

## Checklist:

- [X] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [X] The changes follow the project's style guidelines and introduce no new warnings.
- [X] The changes are fully tested and pass the CI checks.
- [X] I have reviewed my own code changes.
