### PR TITLE
Implement the currently ignored `display` fields in the style

### DIFF
--- a/animator/src/animator.rs
+++ b/animator/src/animator.rs
@@ -300,6 +300,7 @@ impl Animator {
                         duty: Into::<Fraction>::into(visual.coordinate.tick.line.dash.duty).f32(),
                         color: visual.coordinate.tick.color.rgba(),
                     },
+                    display_ticks: visual.coordinate.tick.display,
                     legend: GridLegendConfig {
                         step: (
                             visual.coordinate.number.x.distance.f32(),
@@ -324,6 +325,8 @@ impl Animator {
                                 LeftRightPosition::Right => HPosition::Right,
                             },
                         ),
+                        display_labels: visual.coordinate.axis.display,
+                        display_numbers: visual.coordinate.number.display,
                     },
                 },
                 traps: TrapConfig {
@@ -411,6 +414,7 @@ impl Animator {
                     color: visual.time.font.color.rgba(),
                     family: visual.time.font.family.clone(),
                 },
+                display: visual.time.display,
             },
         };
 

--- a/configs/styles/catpuccin_frappe.nastyle
+++ b/configs/styles/catpuccin_frappe.nastyle
@@ -122,6 +122,7 @@ coordinate {
 				duty: 100%
 			}
 		}
+		display: true
 	}
 	number {
 		x {

--- a/configs/styles/catpuccin_latte.nastyle
+++ b/configs/styles/catpuccin_latte.nastyle
@@ -122,6 +122,7 @@ coordinate {
 				duty: 100%
 			}
 		}
+		display: true
 	}
 	number {
 		x {

--- a/configs/styles/catpuccin_macchiato.nastyle
+++ b/configs/styles/catpuccin_macchiato.nastyle
@@ -122,6 +122,7 @@ coordinate {
 				duty: 100%
 			}
 		}
+		display: true
 	}
 	number {
 		x {

--- a/configs/styles/catpuccin_mocha.nastyle
+++ b/configs/styles/catpuccin_mocha.nastyle
@@ -122,6 +122,7 @@ coordinate {
 				duty: 100%
 			}
 		}
+		display: true
 	}
 	number {
 		x {

--- a/configs/styles/tum.nastyle
+++ b/configs/styles/tum.nastyle
@@ -122,6 +122,7 @@ coordinate {
 				duty: 100%
 			}
 		}
+		display: true
 	}
 	number {
 		x {

--- a/configs/styles/tum_dark.nastyle
+++ b/configs/styles/tum_dark.nastyle
@@ -122,6 +122,7 @@ coordinate {
 				duty: 100%
 			}
 		}
+		display: true
 	}
 	number {
 		x {

--- a/doc/FileFormat.md
+++ b/doc/FileFormat.md
@@ -237,6 +237,7 @@ coordinate {
 				duty: <percentage> // How much of the dash-segment will be filled
 			}
 		}
+		display: <boolean> // Whether to display the coordinate ticks
 	}
 	number {
 		x {

--- a/parser/rsc/test/example.nastyle
+++ b/parser/rsc/test/example.nastyle
@@ -112,6 +112,7 @@ coordinate {
 				duty: 50% // How much of the dash-segment will be filled
 			}
 		}
+		display: true // Whether to display the coordinate ticks
 	}
 	number {
 		x {

--- a/parser/src/config/visual.rs
+++ b/parser/src/config/visual.rs
@@ -414,6 +414,7 @@ pub struct TickConfig {
     pub y: Fraction,
     pub color: Color,
     pub line: LineConfig,
+    pub display: bool,
 }
 
 impl TryFrom<Config> for TickConfig {
@@ -424,6 +425,7 @@ impl TryFrom<Config> for TickConfig {
             y: get_item(&mut value, "y")?,
             color: get_item(&mut value, "color")?,
             line: get_item_struct(&mut value, "line")?,
+            display: get_item(&mut value, "display")?,
         })
     }
 }
@@ -792,6 +794,7 @@ mod test {
                             duty: Percentage(Fraction::new(50u64, 1u64)),
                         },
                     },
+                    display: true,
                 },
                 number: NumberConfig {
                     x: NumberConfigConfig {

--- a/state/src/config.rs
+++ b/state/src/config.rs
@@ -33,6 +33,8 @@ pub struct GridConfig {
     pub line: LineConfig,
     /// The config for the legend at the sides
     pub legend: GridLegendConfig,
+    /// Whether to display the coordinate ticks
+    pub display_ticks: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -45,6 +47,10 @@ pub struct GridLegendConfig {
     pub labels: (String, String),
     /// The position of the labels
     pub position: (VPosition, HPosition),
+    /// Whether to display the labels for the x- and y-axis
+    pub display_labels: bool,
+    /// Whether to display the numbers on the axes
+    pub display_numbers: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -118,6 +124,8 @@ pub struct LegendEntry {
 pub struct TimeConfig {
     /// The config for the font of the time-display
     pub font: FontConfig,
+    /// Whether to display the current time
+    pub display: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -210,6 +218,7 @@ impl Config {
                         duty: 1.,
                         color: [127, 127, 127, 255],
                     },
+                    display_ticks: true,
                     legend: GridLegendConfig {
                         step: (40., 40.),
                         font: FontConfig {
@@ -219,6 +228,8 @@ impl Config {
                         },
                         labels: ("x".to_owned(), "y".to_owned()),
                         position: (VPosition::Bottom, HPosition::Left),
+                        display_labels: true,
+                        display_numbers: true,
                     },
                 },
                 traps: TrapConfig {
@@ -332,6 +343,7 @@ impl Config {
                     color: [0, 0, 0, 255],
                     family: "Fira Mono".to_owned(),
                 },
+                display: true,
             },
             content_extent: ((0., 0.), (100., 120.)),
         }


### PR DESCRIPTION
## Description

Currently, some `display`-fields are ignored from the visual configuration.
This PR makes the visualization respect these attributes.
It also adds an option to hide the coordinate grid.

Partially fixes #88 (hidden elements still get allocated their space).

## Current status

- [X] Add missing options into state
- [X] Add `coordinate.ticks.display`
- [ ] Make animator or renderer respect the added `display`-options

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [X] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
  - Existing tests have been updated
- [X] I have updated the documentation to reflect these changes.
- [X] The changes follow the project's style guidelines and introduce no new warnings.
- [X] The changes are fully tested and pass the CI checks.
- [X] I have reviewed my own code changes.
