### PR TITLE
Add a button to manually toggle the Zen-Mode (independent of the selected style)

### DIFF
--- a/animator/src/animator.rs
+++ b/animator/src/animator.rs
@@ -477,6 +477,11 @@ impl Animator {
 
     /// Format the given [Time] into a time-string according to the [TimeConfig] in the current [VisualConfig].
     fn format_time(&self, time: Time) -> String {
+        if !self.visual.time.display {
+            // Don't display the time
+            return String::new();
+        }
+
         format!(
             "{}{:.*} {}",
             self.visual.time.prefix,

--- a/animator/src/animator.rs
+++ b/animator/src/animator.rs
@@ -439,7 +439,6 @@ impl Animator {
 
     /// Gets the [State] at the passed [Time]
     pub fn state(&self, time: Time) -> State {
-        let time_strings = (&self.visual.time.prefix, &self.machine.time.unit);
         State {
             atoms: self
                 .atoms
@@ -467,19 +466,24 @@ impl Animator {
                     },
                 )
                 .collect(),
-            time: format!(
-                "{}{:.*} {}",
-                time_strings.0,
-                self.visual.time.precision.f64().abs().floor() as usize,
-                time,
-                time_strings.1
-            ),
+            time: self.format_time(time),
         }
     }
 
     /// The background color
     pub fn background(&self) -> [u8; 4] {
         self.visual.viewport.color.rgba()
+    }
+
+    /// Format the given [Time] into a time-string according to the [TimeConfig] in the current [VisualConfig].
+    fn format_time(&self, time: Time) -> String {
+        format!(
+            "{}{:.*} {}",
+            self.visual.time.prefix,
+            self.visual.time.precision.f64().abs().floor() as usize,
+            time,
+            self.machine.time.unit,
+        )
     }
 }
 

--- a/animator/src/animator.rs
+++ b/animator/src/animator.rs
@@ -300,6 +300,7 @@ impl Animator {
                         duty: Into::<Fraction>::into(visual.coordinate.tick.line.dash.duty).f32(),
                         color: visual.coordinate.tick.color.rgba(),
                     },
+                    display_ticks: visual.coordinate.tick.display,
                     legend: GridLegendConfig {
                         step: (
                             visual.coordinate.number.x.distance.f32(),
@@ -324,6 +325,8 @@ impl Animator {
                                 LeftRightPosition::Right => HPosition::Right,
                             },
                         ),
+                        display_labels: visual.coordinate.axis.display,
+                        display_numbers: visual.coordinate.number.display,
                     },
                 },
                 traps: TrapConfig {
@@ -411,6 +414,7 @@ impl Animator {
                     color: visual.time.font.color.rgba(),
                     family: visual.time.font.family.clone(),
                 },
+                display: visual.time.display,
             },
         };
 

--- a/configs/styles/catpuccin_frappe.nastyle
+++ b/configs/styles/catpuccin_frappe.nastyle
@@ -122,6 +122,7 @@ coordinate {
 				duty: 100%
 			}
 		}
+		display: true
 	}
 	number {
 		x {

--- a/configs/styles/catpuccin_latte.nastyle
+++ b/configs/styles/catpuccin_latte.nastyle
@@ -122,6 +122,7 @@ coordinate {
 				duty: 100%
 			}
 		}
+		display: true
 	}
 	number {
 		x {

--- a/configs/styles/catpuccin_macchiato.nastyle
+++ b/configs/styles/catpuccin_macchiato.nastyle
@@ -122,6 +122,7 @@ coordinate {
 				duty: 100%
 			}
 		}
+		display: true
 	}
 	number {
 		x {

--- a/configs/styles/catpuccin_mocha.nastyle
+++ b/configs/styles/catpuccin_mocha.nastyle
@@ -122,6 +122,7 @@ coordinate {
 				duty: 100%
 			}
 		}
+		display: true
 	}
 	number {
 		x {

--- a/configs/styles/tum.nastyle
+++ b/configs/styles/tum.nastyle
@@ -122,6 +122,7 @@ coordinate {
 				duty: 100%
 			}
 		}
+		display: true
 	}
 	number {
 		x {

--- a/configs/styles/tum_dark.nastyle
+++ b/configs/styles/tum_dark.nastyle
@@ -122,6 +122,7 @@ coordinate {
 				duty: 100%
 			}
 		}
+		display: true
 	}
 	number {
 		x {

--- a/doc/FileFormat.md
+++ b/doc/FileFormat.md
@@ -237,6 +237,7 @@ coordinate {
 				duty: <percentage> // How much of the dash-segment will be filled
 			}
 		}
+		display: <boolean> // Whether to display the coordinate ticks
 	}
 	number {
 		x {

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -1,6 +1,11 @@
 use core::str;
+use std::ops::{Deref, DerefMut};
 #[cfg(not(target_arch = "wasm32"))]
-use std::{sync::mpsc::channel, thread};
+use std::{
+    path::{Path, PathBuf},
+    sync::mpsc::Sender,
+    thread,
+};
 
 use eframe::egui_wgpu::CallbackTrait;
 use log::error;
@@ -10,7 +15,7 @@ use naviz_renderer::renderer::Renderer;
 use naviz_repository::Repository;
 use naviz_state::{config::Config, state::State};
 #[cfg(not(target_arch = "wasm32"))]
-use naviz_video::VideoExport;
+use naviz_video::{VideoExport, VideoProgress};
 
 use crate::{
     animator_adapter::{AnimatorAdapter, AnimatorState},
@@ -22,31 +27,164 @@ use crate::{
         RepositoryLoadSource, Result,
     },
     errors::{ErrorEmitter, Errors},
+    file_type::FileType,
     future_helper::FutureHelper,
     init::{IdOrManual, InitOptions, Persistence},
-    menu::{FileType, MenuBar, MenuConfig, MenuEvent},
+    menu::MenuBar,
     util::WEB,
 };
 
-/// The main App to draw using [egui]/[eframe]
+/// The main App to draw using [egui]/[eframe].
+///
+/// Can be dereferenced to [AppState] to interface with and update the state.
 pub struct App {
+    state: AppState,
+    ui: AppUI,
     future_helper: FutureHelper,
-    menu_bar: MenuBar,
+}
+
+/// The state of the app.
+/// Contains all internal state and the interface to update the app's state.
+/// Is contained in the [App].
+pub struct AppState {
     animator_adapter: AnimatorAdapter,
     machine_repository: Repository,
     style_repository: Repository,
     current_machine: CurrentMachine,
-    errors: Errors,
+    current_style_id: Option<String>,
     persistence: Persistence,
+    cache: AppCache,
+}
+
+/// Caches some states of the app for operations such as sorting.
+#[derive(Default)]
+struct AppCache {
+    /// sorted machine list
+    machines: Vec<(String, String, bool)>,
+    /// sorted style list
+    styles: Vec<(String, String, bool)>,
+}
+
+impl AppCache {
+    /// Materializes the [list][Repository::list] of the passed [Repository].
+    fn materialize(repo: &Repository) -> Vec<(String, String, bool)> {
+        repo.list()
+            .map(|(id, name, removable)| (id.to_string(), name.to_string(), removable))
+            .collect()
+    }
+
+    /// Iterates over the passed list
+    fn iter(vec: &[(String, String, bool)]) -> impl Iterator<Item = (&str, &str, bool)> {
+        vec.iter()
+            .map(|(id, name, removable)| (id.as_str(), name.as_str(), *removable))
+    }
+
+    /// Updates the cached list of machines from the passed machine-[Repository] and the passed list of compatible machine-IDs
+    pub fn update_machines(&mut self, machine_repository: &Repository, compatible: &[String]) {
+        self.machines = Self::materialize(machine_repository);
+        self.machines
+            .sort_by(|(a_id, a_name, _), (b_id, b_name, _)| {
+                compatible
+                    .contains(a_id)
+                    .cmp(&compatible.contains(b_id))
+                    .reverse()
+                    .then_with(|| a_name.cmp(b_name))
+            });
+    }
+
+    /// Updates the cached list of styles from the passed style-[Repository]
+    pub fn update_styles(&mut self, style_repository: &Repository) {
+        self.styles = Self::materialize(style_repository);
+        self.styles
+            .sort_by(|(_, a_name, _), (_, b_name, _)| a_name.cmp(b_name));
+    }
+
+    /// Gets the (cached and sorted) list of machines
+    pub fn machines(&self) -> impl Iterator<Item = (&str, &str, bool)> {
+        Self::iter(&self.machines)
+    }
+
+    /// Gets the (cached and sorted) list of styles
+    pub fn styles(&self) -> impl Iterator<Item = (&str, &str, bool)> {
+        Self::iter(&self.styles)
+    }
+}
+
+/// The UI-elements of the [App].
+struct AppUI {
+    menu_bar: MenuBar,
+    errors: Errors,
+}
+
+impl Deref for App {
+    type Target = AppState;
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
+impl DerefMut for App {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.state
+    }
 }
 
 impl App {
-    /// Create a new instance of the [App]
-    pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        RendererAdapter::setup(cc);
-
+    /// Creates a new [App] by constructing an [AppState].
+    /// Also [sets up][RendererAdapter::setup] a [RendererAdapter].
+    ///
+    /// Can be used to delegate to one of the [AppState]-constructors.
+    fn new_from_state(
+        cc: &eframe::CreationContext<'_>,
+        constructor: impl FnOnce(&mut Errors) -> AppState,
+    ) -> Self {
         let mut errors = Errors::default();
 
+        RendererAdapter::setup(cc);
+
+        Self {
+            state: constructor(&mut errors),
+            ui: AppUI {
+                menu_bar: MenuBar::new(),
+                errors,
+            },
+            future_helper: FutureHelper::new().expect("Failed to create FutureHelper"), // This is unrecoverable
+        }
+    }
+
+    /// Create a new instance of the [App]
+    pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
+        Self::new_from_state(cc, AppState::new)
+    }
+
+    /// Create a new instance of the [App] with the specified [InitOptions]
+    pub fn new_with_init(cc: &eframe::CreationContext<'_>, init_options: InitOptions<'_>) -> Self {
+        Self::new_from_state(cc, |errors| AppState::new_with_init(init_options, errors))
+    }
+
+    /// Create a new instance of the [AppState] with the specified [InitOptions]
+    /// and loading the last persisted state.
+    /// The passed [InitOptions] will overwrite any persisted options.
+    pub fn new_with_init_and_persistence(
+        cc: &eframe::CreationContext<'_>,
+        init_options: InitOptions<'_>,
+    ) -> Self {
+        Self::new_from_state(cc, |errors| {
+            AppState::new_with_init_and_persistence(Persistence::load(cc), init_options, errors)
+        })
+    }
+
+    /// Gets the [Errors]-instance of this [App],
+    /// which can be used to pipe [Error]s to.
+    pub fn errors(&mut self) -> &mut Errors {
+        &mut self.ui.errors
+    }
+}
+
+impl AppState {
+    /// Create a new instance of the [AppState].
+    /// Errors will be piped to the passed [Errors].
+    fn new(errors: &mut Errors) -> Self {
         let mut machine_repository = Repository::empty()
             .bundled_machines()
             .map_err(|e| {
@@ -55,7 +193,7 @@ impl App {
                     ConfigFormat::Machine,
                 )
             })
-            .pipe(&mut errors, Repository::empty);
+            .pipe(errors, Repository::empty);
         let mut style_repository = Repository::empty()
             .bundled_styles()
             .map_err(|e| {
@@ -64,7 +202,7 @@ impl App {
                     ConfigFormat::Style,
                 )
             })
-            .pipe(&mut errors, Repository::empty);
+            .pipe(errors, Repository::empty);
 
         // Load user-dirs only on non-web builds as there is no filesystem on web
         if !WEB {
@@ -76,7 +214,7 @@ impl App {
                         ConfigFormat::Machine,
                     )
                 })
-                .pipe(&mut errors, Repository::empty);
+                .pipe(errors, Repository::empty);
             style_repository = style_repository
                 .user_dir_styles()
                 .map_err(|e| {
@@ -85,18 +223,17 @@ impl App {
                         ConfigFormat::Machine,
                     )
                 })
-                .pipe(&mut errors, Repository::empty);
+                .pipe(errors, Repository::empty);
         }
 
         let mut app = Self {
-            future_helper: FutureHelper::new().expect("Failed to create FutureHelper"), // This is unrecoverable
-            menu_bar: MenuBar::new(),
             animator_adapter: AnimatorAdapter::default(),
             machine_repository,
             style_repository,
             current_machine: Default::default(),
-            errors,
+            current_style_id: None,
             persistence: Default::default(),
+            cache: Default::default(),
         };
 
         app.update_machines();
@@ -114,16 +251,17 @@ impl App {
         app
     }
 
-    /// Create a new instance of the [App] with the specified [InitOptions]
-    pub fn new_with_init(cc: &eframe::CreationContext<'_>, init_options: InitOptions<'_>) -> Self {
-        let mut app = Self::new(cc);
+    /// Create a new instance of the [AppState] with the specified [InitOptions].
+    /// Errors will be piped to the passed [Errors].
+    fn new_with_init(init_options: InitOptions<'_>, errors: &mut Errors) -> Self {
+        let mut app = Self::new(errors);
 
         if let Some((import_options, data)) = init_options.input {
             match import_options {
                 Some(import_options) => app.import(import_options, data).map_err(Error::Import),
                 None => app.open(data),
             }
-            .pipe_void(&mut app.errors)
+            .pipe_void(errors)
         }
 
         if let Some(machine) = init_options.machine {
@@ -131,32 +269,33 @@ impl App {
                 IdOrManual::Id(machine_id) => app.set_machine(machine_id),
                 IdOrManual::Manual(data) => app.set_machine_manually(data),
             }
-            .pipe_void(&mut app.errors)
+            .pipe_void(errors)
         }
         if let Some(style) = init_options.style {
             match style {
                 IdOrManual::Id(style_id) => app.set_style(style_id),
                 IdOrManual::Manual(data) => app.set_style_manually(data),
             }
-            .pipe_void(&mut app.errors)
+            .pipe_void(errors)
         }
 
         app
     }
 
-    /// Create a new instance of the [App] with the specified [InitOptions]
-    /// and loading the last persisted state.
-    /// The passed [InitOptions] will overwrite any persisted options.
-    pub fn new_with_init_and_persistence(
-        cc: &eframe::CreationContext<'_>,
+    /// Create a new instance of the [AppState] with the specified [InitOptions] and [Persistence].
+    /// The passed [InitOptions] will overwrite options in [Persistence].
+    /// Errors will be piped to the passed [Errors].
+    fn new_with_init_and_persistence(
+        persistence: Option<Persistence>,
         init_options: InitOptions<'_>,
+        errors: &mut Errors,
     ) -> Self {
-        if let Some(persistence) = Persistence::load(cc) {
+        if let Some(persistence) = persistence {
             let persisted: InitOptions<'_> = (&persistence).into();
-            Self::new_with_init(cc, persisted.merge(init_options))
+            Self::new_with_init(persisted.merge(init_options), errors)
         } else {
             // Nothing previously persisted
-            Self::new_with_init(cc, init_options)
+            Self::new_with_init(init_options, errors)
         }
     }
 
@@ -168,7 +307,7 @@ impl App {
     ) -> Result<(), ImportError> {
         let instructions = import_options.import(data)?;
         self.animator_adapter.set_instructions(instructions);
-        self.update_compatible_machines();
+        self.update_machines(); // update compatible machines
         Ok(())
     }
 
@@ -185,9 +324,18 @@ impl App {
         let input = naviz_parser::input::concrete::Instructions::new(input)
             .map_err(|e| Error::FileOpen(InputType::Instruction(InputError::Convert(e))))?;
         self.animator_adapter.set_instructions(input);
-        self.update_compatible_machines();
+        self.update_machines(); // update compatible machines
         self.select_compatible_machine()?;
         Ok(())
+    }
+
+    /// Opens a file by [FileType].
+    pub fn open_by_type(&mut self, file_type: FileType, data: &[u8]) -> Result<()> {
+        match file_type {
+            FileType::Instructions => self.open(data),
+            FileType::Machine => self.set_machine_manually(data),
+            FileType::Style => self.set_style_manually(data),
+        }
     }
 
     /// Selects any compatible machine for the currently opened machine.
@@ -254,7 +402,6 @@ impl App {
             .clone()
             .map(CurrentMachine::Id)
             .unwrap_or(CurrentMachine::Manual);
-        self.menu_bar.set_selected_machine(id);
         self.animator_adapter.set_machine_config(machine);
     }
 
@@ -311,7 +458,7 @@ impl App {
     /// Sets the current style to `style` with the optional `id`.
     /// If `id` is [None], the style is assumed to be set manually.
     fn set_loaded_style(&mut self, id: Option<impl Into<String>>, style: VisualConfig) {
-        self.menu_bar.set_selected_style(id.map(Into::into));
+        self.current_style_id = id.map(Into::into);
         self.animator_adapter.set_visual_config(style);
     }
 
@@ -345,132 +492,125 @@ impl App {
         Ok(())
     }
 
-    /// Update the machines displayed in the menu from the repository
-    fn update_machines(&mut self) {
-        self.menu_bar.update_machines(
-            self.machine_repository
-                .list()
-                .into_iter()
-                .map(|(id, name, removable)| (id.to_owned(), name.to_owned(), removable))
-                .collect(),
-        );
+    /// Gets the ID of the currently selected machine
+    /// or [None] if the current machine does not have an ID
+    /// (i.e., is loaded from memory).
+    pub fn get_current_machine_id(&self) -> Option<&str> {
+        self.current_machine.id()
     }
 
-    /// Update the compatible machines to be the ones specified in the currently loaded instructions
-    fn update_compatible_machines(&mut self) {
-        self.menu_bar.set_compatible_machines(
+    /// Gets the ID of the currently selected style
+    /// or [None] if the current style does not have an ID
+    /// (i.e., is loaded from memory).
+    pub fn get_current_style_id(&self) -> Option<&str> {
+        self.current_style_id.as_deref()
+    }
+
+    /// Gets the list of loaded machines.
+    /// Will be sorted by name and compatible machines will be at the top.
+    pub fn get_machines(&self) -> impl Iterator<Item = (&str, &str, bool)> {
+        self.cache.machines()
+    }
+
+    /// Gets the list of loaded styles sorted by name.
+    pub fn get_styles(&self) -> impl Iterator<Item = (&str, &str, bool)> {
+        self.cache.styles()
+    }
+
+    /// Imports a machine to the repository by the specified `path`.
+    /// The id will be set to the file name.
+    /// See [Repository::import_machine_to_user_dir].
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn import_machine(&mut self, path: &Path) -> Result<()> {
+        self.machine_repository
+            .import_machine_to_user_dir(path)
+            .map_err(|e| Error::Repository(RepositoryError::Import(e), ConfigFormat::Machine))?;
+        self.update_machines();
+        Ok(())
+    }
+
+    /// Imports a style to the repository by the specified `path`.
+    /// The id will be set to the file name.
+    /// See [Repository::import_style_to_user_dir].
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn import_style(&mut self, path: &Path) -> Result<()> {
+        self.style_repository
+            .import_style_to_user_dir(path)
+            .map_err(|e| Error::Repository(RepositoryError::Import(e), ConfigFormat::Style))?;
+        self.update_styles();
+        Ok(())
+    }
+
+    /// Removes an imported machine from the repository.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn remove_machine(&mut self, id: &str) -> Result<()> {
+        self.machine_repository
+            .remove_from_user_dir(id)
+            .map_err(|e| Error::Repository(RepositoryError::Remove(e), ConfigFormat::Machine))?;
+        self.update_machines();
+        Ok(())
+    }
+
+    /// Removes an imported style from the repository.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn remove_style(&mut self, id: &str) -> Result<()> {
+        self.style_repository
+            .remove_from_user_dir(id)
+            .map_err(|e| Error::Repository(RepositoryError::Remove(e), ConfigFormat::Style))?;
+        self.update_styles();
+        Ok(())
+    }
+
+    /// Starts an export of the visualization to the specified `target`-path
+    /// with the specified `resolution` and `fps`.
+    /// Updates will be sent over the `progress`-channel.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn export(
+        &self,
+        target: PathBuf,
+        resolution: (u32, u32),
+        fps: u32,
+        progress: Sender<VideoProgress>,
+    ) {
+        if let Some(animator) = self.animator_adapter.animator() {
+            let video = VideoExport::new(animator, resolution, fps);
+            thread::spawn(move || {
+                let mut video = futures::executor::block_on(video);
+                video.export_video(&target, progress);
+            });
+        }
+    }
+
+    /// Updates the cached list of machines
+    fn update_machines(&mut self) {
+        self.cache.update_machines(
+            &self.machine_repository,
             self.animator_adapter
                 .get_instructions()
-                .map(|x| x.directives.targets.as_slice())
+                .map(|i| i.directives.targets.as_slice())
                 .unwrap_or(&[]),
         );
     }
 
-    /// Update the styles displayed in the menu from the repository
+    /// Updates the cached list of styles
     fn update_styles(&mut self) {
-        self.menu_bar.update_styles(
-            self.style_repository
-                .list()
-                .into_iter()
-                .map(|(id, name, removable)| (id.to_owned(), name.to_owned(), removable))
-                .collect(),
-        );
+        self.cache.update_styles(&self.style_repository);
+    }
+
+    /// Returns whether a visualization is currently loaded:
+    /// Some machine and style is selected and some instructions are loaded.
+    pub fn visualization_loaded(&self) -> bool {
+        self.animator_adapter.all_inputs_set()
     }
 }
 
 impl eframe::App for App {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        // Check if a new file was read
-        if let Ok(event) = self.menu_bar.events().try_recv() {
-            match event {
-                MenuEvent::FileOpen(FileType::Instructions, content) => {
-                    self.open(&content).pipe_void(&mut self.errors);
-                }
-                MenuEvent::FileImport(options, content) => {
-                    self.import(options, &content)
-                        .map_err(Error::Import)
-                        .pipe_void(&mut self.errors);
-                }
-                MenuEvent::FileOpen(FileType::Machine, content) => {
-                    self.set_machine_manually(&content)
-                        .pipe_void(&mut self.errors);
-                }
-                MenuEvent::FileOpen(FileType::Style, content) => {
-                    self.set_style_manually(&content)
-                        .pipe_void(&mut self.errors);
-                }
-                #[cfg(not(target_arch = "wasm32"))]
-                MenuEvent::ExportVideo {
-                    target,
-                    resolution,
-                    fps,
-                    progress,
-                } => {
-                    if let Some(animator) = self.animator_adapter.animator() {
-                        let video = VideoExport::new(animator, resolution, fps);
-                        let (tx, rx) = channel();
-                        self.future_helper.execute_to(video, tx);
-                        thread::spawn(move || {
-                            let mut video = rx.recv().unwrap();
-                            video.export_video(&target, progress);
-                        });
-                    }
-                }
-                MenuEvent::SetMachine(id) => {
-                    self.set_machine(id).pipe_void(&mut self.errors);
-                }
-                MenuEvent::SetStyle(id) => {
-                    self.set_style(id).pipe_void(&mut self.errors);
-                }
-                #[cfg(not(target_arch = "wasm32"))]
-                MenuEvent::ImportMachine(file) => {
-                    self.machine_repository
-                        .import_machine_to_user_dir(&file)
-                        .map_err(|e| {
-                            Error::Repository(RepositoryError::Import(e), ConfigFormat::Machine)
-                        })
-                        .pipe_void(&mut self.errors);
-                    self.update_machines();
-                }
-                #[cfg(not(target_arch = "wasm32"))]
-                MenuEvent::ImportStyle(file) => {
-                    self.style_repository
-                        .import_style_to_user_dir(&file)
-                        .map_err(|e| {
-                            Error::Repository(RepositoryError::Import(e), ConfigFormat::Style)
-                        })
-                        .pipe_void(&mut self.errors);
-                    self.update_styles();
-                }
-                #[cfg(not(target_arch = "wasm32"))]
-                MenuEvent::RemoveMachine(id) => {
-                    self.machine_repository
-                        .remove_from_user_dir(&id)
-                        .map_err(|e| {
-                            Error::Repository(RepositoryError::Remove(e), ConfigFormat::Machine)
-                        })
-                        .pipe_void(&mut self.errors);
-                    self.update_machines();
-                }
-                #[cfg(not(target_arch = "wasm32"))]
-                MenuEvent::RemoveStyle(id) => {
-                    self.style_repository
-                        .remove_from_user_dir(&id)
-                        .map_err(|e| {
-                            Error::Repository(RepositoryError::Remove(e), ConfigFormat::Style)
-                        })
-                        .pipe_void(&mut self.errors);
-                    self.update_styles();
-                }
-            }
-        }
-
         // Menu
         egui::TopBottomPanel::top("app_menu").show(ctx, |ui| {
-            self.menu_bar.draw(
-                MenuConfig {
-                    export: self.animator_adapter.all_inputs_set(),
-                },
+            self.ui.menu_bar.draw(
+                &mut self.state,
+                &mut self.ui.errors,
                 &self.future_helper,
                 ctx,
                 ui,
@@ -510,7 +650,7 @@ impl eframe::App for App {
             );
         });
 
-        self.errors.draw(ctx);
+        self.ui.errors.draw(ctx);
     }
 
     fn save(&mut self, storage: &mut dyn eframe::Storage) {

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -602,6 +602,17 @@ impl AppState {
     pub fn visualization_loaded(&self) -> bool {
         self.animator_adapter.all_inputs_set()
     }
+
+    /// Whether to force the zen-mode.
+    /// See [Renderer::set_force_zen].
+    pub fn set_force_zen(&mut self, force_zen: bool) {
+        self.animator_adapter.set_force_zen(force_zen);
+    }
+
+    /// Gets whether the zen-mode is currently forced as set by [AppState::set_force_zen]
+    pub fn get_force_zen(&mut self) -> bool {
+        self.animator_adapter.get_force_zen()
+    }
 }
 
 impl eframe::App for App {

--- a/gui/src/current_machine.rs
+++ b/gui/src/current_machine.rs
@@ -25,4 +25,12 @@ impl CurrentMachine {
             Self::Id(id) => compatible_machines.contains(id),
         }
     }
+
+    /// Gets the `id`` of this [CurrentMachine] if it is set to [CurrentMachine::Id].
+    pub fn id(&self) -> Option<&str> {
+        match self {
+            Self::Id(id) => Some(id),
+            _ => None,
+        }
+    }
 }

--- a/gui/src/file_type.rs
+++ b/gui/src/file_type.rs
@@ -1,0 +1,32 @@
+/// The available FileTypes that can be opened
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FileType {
+    Instructions,
+    Machine,
+    Style,
+}
+
+/// Something which can be used to filter files by extension
+pub trait FileFilter {
+    /// The name of this filter
+    fn name(&self) -> &str;
+    /// Allowed extensions
+    fn extensions(&self) -> &[&str];
+}
+
+impl FileFilter for FileType {
+    fn name(&self) -> &'static str {
+        match self {
+            FileType::Instructions => "NAViz instructions",
+            FileType::Machine => "NAViz machine",
+            FileType::Style => "NAViz style",
+        }
+    }
+    fn extensions(&self) -> &'static [&'static str] {
+        match self {
+            FileType::Instructions => &["naviz"],
+            FileType::Machine => &["namachine"],
+            FileType::Style => &["nastyle"],
+        }
+    }
+}

--- a/gui/src/import.rs
+++ b/gui/src/import.rs
@@ -3,7 +3,7 @@
 use egui::{TextEdit, Ui};
 use naviz_import::{ImportFormat, ImportOptions};
 
-use crate::{drawable::Drawable, menu::FileFilter};
+use crate::{drawable::Drawable, file_type::FileFilter};
 
 impl FileFilter for ImportFormat {
     fn name(&self) -> &'static str {

--- a/gui/src/lib.rs
+++ b/gui/src/lib.rs
@@ -10,6 +10,7 @@ mod error;
 mod errors;
 #[cfg(not(target_arch = "wasm32"))]
 mod export_dialog;
+pub mod file_type;
 mod future_helper;
 mod import;
 pub mod init;

--- a/gui/src/menu.rs
+++ b/gui/src/menu.rs
@@ -248,6 +248,15 @@ impl MenuBar {
             // Style selection
             selection_menu::draw::<selection_menu::Style>(state, ui, future_helper, self, errors);
 
+            // View-menu
+            ui.menu_button("View", |ui| {
+                // Zen-overwrite
+                let mut force_zen = state.get_force_zen();
+                if ui.checkbox(&mut force_zen, "Zen-Mode").changed() {
+                    state.set_force_zen(force_zen);
+                }
+            });
+
             ui.menu_button("Help", |ui| {
                 if ui.button("About").clicked() {
                     self.about_open = true;

--- a/parser/rsc/test/example.nastyle
+++ b/parser/rsc/test/example.nastyle
@@ -112,6 +112,7 @@ coordinate {
 				duty: 50% // How much of the dash-segment will be filled
 			}
 		}
+		display: true // Whether to display the coordinate ticks
 	}
 	number {
 		x {

--- a/parser/src/config/visual.rs
+++ b/parser/src/config/visual.rs
@@ -414,6 +414,7 @@ pub struct TickConfig {
     pub y: Fraction,
     pub color: Color,
     pub line: LineConfig,
+    pub display: bool,
 }
 
 impl TryFrom<Config> for TickConfig {
@@ -424,6 +425,7 @@ impl TryFrom<Config> for TickConfig {
             y: get_item(&mut value, "y")?,
             color: get_item(&mut value, "color")?,
             line: get_item_struct(&mut value, "line")?,
+            display: get_item(&mut value, "display")?,
         })
     }
 }
@@ -792,6 +794,7 @@ mod test {
                             duty: Percentage(Fraction::new(50u64, 1u64)),
                         },
                     },
+                    display: true,
                 },
                 number: NumberConfig {
                     x: NumberConfigConfig {

--- a/renderer/src/component.rs
+++ b/renderer/src/component.rs
@@ -14,12 +14,14 @@ use wgpu::{
 
 use crate::{
     buffer_updater::BufferUpdater,
+    component::drawable::Drawable,
     globals::Globals,
     shaders::compile_shader,
     viewport::{Viewport, ViewportProjection},
 };
 
 pub mod atoms;
+pub mod drawable;
 pub mod legend;
 pub mod machine;
 pub mod primitive;
@@ -199,5 +201,17 @@ impl<Spec: bytemuck::NoUninit> Component<Spec> {
         render_pass.set_vertex_buffer(0, self.instance_buffer.slice(..));
         render_pass.set_bind_group(2, &self.bind_group, &[]);
         render_pass.draw(0..6, 0..self.instance_count);
+    }
+}
+
+impl<Spec: bytemuck::NoUninit> Drawable for Component<Spec> {
+    #[inline]
+    fn draw<const REBIND: bool>(
+        &self,
+        render_pass: &mut RenderPass<'_>,
+        _rebind: impl Fn(&mut RenderPass),
+    ) {
+        // no bindings are changed, therefore we never need to rebind
+        self.draw(render_pass);
     }
 }

--- a/renderer/src/component/atoms.rs
+++ b/renderer/src/component/atoms.rs
@@ -6,6 +6,7 @@ use wgpu::{Device, Queue, RenderPass};
 
 use crate::{
     buffer_updater::BufferUpdater,
+    component::drawable::Drawable,
     viewport::{Viewport, ViewportProjection},
 };
 
@@ -85,12 +86,14 @@ impl Atoms {
         self.labels
             .update_viewport((device, queue), screen_resolution);
     }
+}
 
+impl Drawable for Atoms {
     /// Draws these [Atoms].
     ///
     /// May overwrite bind groups.
     /// If `REBIND` is `true`, will call the passed `rebind`-function to rebind groups.
-    pub fn draw<const REBIND: bool>(
+    fn draw<const REBIND: bool>(
         &self,
         render_pass: &mut RenderPass<'_>,
         rebind: impl Fn(&mut RenderPass),

--- a/renderer/src/component/drawable.rs
+++ b/renderer/src/component/drawable.rs
@@ -1,0 +1,16 @@
+use wgpu::RenderPass;
+
+/// A trait for something which can be drawn/rendered.
+pub trait Drawable {
+    /// Draws this [Drawable], optionally calling `rebind` if enabled by setting `REBIND`-parameter to `true`.
+    ///
+    /// Note: `rebind` is intended to get the bindings into their initial state.
+    /// Implementations that do not change any bindings may therefore choose not to call `rebind`,
+    /// even when `REBIND` is set to `true`.
+    /// If you want to always modify the bindings, do so after the call instead.
+    fn draw<const REBIND: bool>(
+        &self,
+        render_pass: &mut RenderPass<'_>,
+        rebind: impl Fn(&mut RenderPass),
+    );
+}

--- a/renderer/src/component/drawable.rs
+++ b/renderer/src/component/drawable.rs
@@ -1,3 +1,5 @@
+use std::ops::{Deref, DerefMut};
+
 use wgpu::RenderPass;
 
 /// A trait for something which can be drawn/rendered.
@@ -13,4 +15,60 @@ pub trait Drawable {
         render_pass: &mut RenderPass<'_>,
         rebind: impl Fn(&mut RenderPass),
     );
+}
+
+/// A [Drawable] which wraps a child-[Drawable] and decides whether the child is visible or hidden.
+/// If the child is not visible, it will never be drawn.
+pub struct Hidable<Child: Drawable> {
+    visible: bool,
+    child: Child,
+}
+
+impl<Child: Drawable> Hidable<Child> {
+    /// Creates a new [Hidable] wrapping the passed `child`.
+    /// Will be visible by default.
+    pub fn new(child: Child) -> Self {
+        Self {
+            visible: true,
+            child,
+        }
+    }
+
+    /// Update the visibility of this [Hidable]
+    pub fn set_visible(&mut self, visible: bool) {
+        self.visible = visible;
+    }
+
+    /// Update the visibility of this [Hidable]
+    pub fn with_visibility(mut self, visible: bool) -> Self {
+        self.set_visible(visible);
+        self
+    }
+}
+
+impl<Child: Drawable> Drawable for Hidable<Child> {
+    fn draw<const REBIND: bool>(
+        &self,
+        render_pass: &mut RenderPass<'_>,
+        rebind: impl Fn(&mut RenderPass),
+    ) {
+        if !self.visible {
+            // no bindings are changed, therefore we never need to rebind
+            return;
+        }
+        self.child.draw::<REBIND>(render_pass, rebind);
+    }
+}
+
+impl<Child: Drawable> Deref for Hidable<Child> {
+    type Target = Child;
+    fn deref(&self) -> &Self::Target {
+        &self.child
+    }
+}
+
+impl<Child: Drawable> DerefMut for Hidable<Child> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.child
+    }
 }

--- a/renderer/src/component/legend.rs
+++ b/renderer/src/component/legend.rs
@@ -6,6 +6,7 @@ use wgpu::{Device, Queue, RenderPass};
 
 use crate::{
     buffer_updater::BufferUpdater,
+    component::drawable::Drawable,
     viewport::{Viewport, ViewportProjection},
 };
 
@@ -61,12 +62,14 @@ impl Legend {
         self.text
             .update_viewport((device, queue), screen_resolution);
     }
+}
 
+impl Drawable for Legend {
     /// Draws this [Legend].
     ///
     /// May overwrite bind groups.
     /// If `REBIND` is `true`, will call the passed `rebind`-function to rebind groups.
-    pub fn draw<const REBIND: bool>(
+    fn draw<const REBIND: bool>(
         &self,
         render_pass: &mut RenderPass<'_>,
         rebind: impl Fn(&mut RenderPass),

--- a/renderer/src/component/machine.rs
+++ b/renderer/src/component/machine.rs
@@ -1,12 +1,14 @@
 use naviz_state::{
-    config::{Config, HPosition, LineConfig, MachineConfig, VPosition, ZoneConfig},
+    config::{
+        Config, GridConfig, HPosition, LineConfig, MachineConfig, TrapConfig, VPosition, ZoneConfig,
+    },
     state::State,
 };
 use wgpu::{Device, Queue, RenderPass};
 
 use crate::{
     buffer_updater::BufferUpdater,
-    viewport::{Viewport, ViewportProjection},
+    viewport::{Viewport, ViewportProjection, ViewportSource},
 };
 
 use super::{
@@ -164,42 +166,68 @@ fn get_specs<'a>(
     text_buffer: &'a mut Vec<(String, (f32, f32), Alignment)>,
 ) -> MachineSpec<'a, impl IntoIterator<Item = (&'a str, (f32, f32), Alignment)>> {
     let MachineConfig { grid, traps, zones } = &config.machine;
+    let viewport_source = viewport_projection.source;
 
-    // The viewport edges
-    let vp_left = viewport_projection.source.left();
-    let vp_right = viewport_projection.source.right();
-    let vp_top = viewport_projection.source.top();
-    let vp_bottom = viewport_projection.source.bottom();
+    let lines = get_grid_lines_specs(grid, viewport_source);
+
+    let traps = get_trap_specs(traps);
+
+    build_number_labels(grid, text_buffer, viewport_source);
+    let texts = add_grid_legend(
+        grid,
+        viewport_source,
+        text_buffer.iter().map(|(t, p, a)| (t.as_str(), *p, *a)),
+    );
+
+    let zones = get_zone_specs(zones);
+
+    MachineSpec {
+        lines,
+        traps,
+        labels: TextSpec {
+            viewport_projection,
+            font_size: grid.legend.font.size,
+            font_family: &grid.legend.font.family,
+            texts,
+            color: grid.legend.font.color,
+        },
+        zones,
+    }
+}
+
+/// Create the [LineSpec]s for the grid fit to the [ViewportSource].
+#[inline]
+fn get_grid_lines_specs(grid: &GridConfig, vp: ViewportSource) -> Vec<LineSpec> {
     // The viewport-edges clamped to the grid/legend steps
-    let vp_left_grid = vp_left - vp_left % grid.step.0;
-    let vp_top_grid = vp_top - vp_top % grid.step.1;
-    let vp_left_legend = vp_left - vp_left % grid.legend.step.0;
-    let vp_top_legend = vp_top - vp_top % grid.legend.step.1;
+    let vp_left_grid = clamp_to(vp.left(), grid.step.0);
+    let vp_top_grid = clamp_to(vp.top(), grid.step.1);
 
-    // Create the LineSpecs for the grid; first x, then y
-    let lines: Vec<_> = range_f32(vp_left_grid, vp_right, grid.step.0)
+    // create LineSpecs; first x, then y
+    range_f32(vp_left_grid, vp.right(), grid.step.0)
         .map(|x| LineSpec {
-            start: [x, vp_top],
-            end: [x, vp_bottom],
+            start: [x, vp.top()],
+            end: [x, vp.bottom()],
             color: grid.line.color,
             width: grid.line.width,
             segment_length: grid.line.segment_length,
             duty: grid.line.duty,
         })
         .chain(
-            range_f32(vp_top_grid, vp_bottom, grid.step.1).map(|y| LineSpec {
-                start: [vp_left, y],
-                end: [vp_right, y],
+            range_f32(vp_top_grid, vp.bottom(), grid.step.1).map(|y| LineSpec {
+                start: [vp.left(), y],
+                end: [vp.right(), y],
                 color: grid.line.color,
                 width: grid.line.width,
                 segment_length: grid.line.segment_length,
                 duty: grid.line.duty,
             }),
         )
-        .collect();
+        .collect()
+}
 
-    // Create the CircleSpecs for the static traps
-    let traps: Vec<_> = traps
+/// Create the [CircleSpec]s for the static traps
+fn get_trap_specs(traps: &TrapConfig) -> Vec<CircleSpec> {
+    traps
         .positions
         .iter()
         .map(|(x, y)| CircleSpec {
@@ -208,11 +236,20 @@ fn get_specs<'a>(
             radius_inner: traps.radius - traps.line_width,
             color: traps.color,
         })
-        .collect();
+        .collect()
+}
 
-    // Create the text specs for the numbers numbers (x then y)
-    // First create strings, then convert to text spec
-    *text_buffer = range_f32(vp_left_legend, vp_right, grid.legend.step.0)
+/// Fill the `text_buffer` with the strings for the legend numbers in x- and y-direction.
+fn build_number_labels(
+    grid: &GridConfig,
+    text_buffer: &mut Vec<(String, (f32, f32), Alignment)>,
+    vp: ViewportSource,
+) {
+    // The viewport-edges clamped to the grid/legend steps
+    let vp_left_legend = clamp_to(vp.left(), grid.legend.step.0);
+    let vp_top_legend = clamp_to(vp.top(), grid.legend.step.1);
+
+    *text_buffer = range_f32(vp_left_legend, vp.right(), grid.legend.step.0)
         .map(|x| {
             (
                 format!("{x}"),
@@ -221,20 +258,20 @@ fn get_specs<'a>(
                     grid.legend
                         .position
                         .0
-                        .get(vp_top - LABEL_PADDING, vp_bottom + LABEL_PADDING),
+                        .get(vp.top() - LABEL_PADDING, vp.bottom() + LABEL_PADDING),
                 ),
                 Alignment(HAlignment::Center, get_v_alignment(grid.legend.position.0)),
             )
         })
         .chain(
-            range_f32(vp_top_legend, vp_bottom, grid.legend.step.1).map(|y| {
+            range_f32(vp_top_legend, vp.bottom(), grid.legend.step.1).map(|y| {
                 (
                     format!("{y}"),
                     (
                         grid.legend
                             .position
                             .1
-                            .get(vp_left - LABEL_PADDING, vp_right + LABEL_PADDING),
+                            .get(vp.left() - LABEL_PADDING, vp.right() + LABEL_PADDING),
                         y,
                     ),
                     Alignment(get_h_alignment(grid.legend.position.1), VAlignment::Center),
@@ -242,9 +279,19 @@ fn get_specs<'a>(
             }),
         )
         .collect();
-    let texts = text_buffer.iter().map(|(t, p, a)| (t.as_str(), *p, *a));
+}
+
+/// Add the grid legends to the `texts`
+#[inline]
+fn add_grid_legend<'a>(
+    grid: &'a GridConfig,
+    vp: ViewportSource,
+    texts: impl IntoIterator<Item = (&'a str, (f32, f32), Alignment)>,
+) -> impl Iterator<Item = (&'a str, (f32, f32), Alignment)> {
+    let texts = texts.into_iter();
+
     // Add axis labels
-    let texts = texts.chain([
+    texts.chain(vec![
         (
             grid.legend.labels.0.as_str(),
             (
@@ -252,8 +299,8 @@ fn get_specs<'a>(
                     .position
                     .1
                     .inverse()
-                    .get(vp_left - LABEL_PADDING, vp_right + LABEL_PADDING),
-                grid.legend.position.0.get(vp_top, vp_bottom),
+                    .get(vp.left() - LABEL_PADDING, vp.right() + LABEL_PADDING),
+                grid.legend.position.0.get(vp.top(), vp.bottom()),
             ),
             Alignment(
                 get_h_alignment(grid.legend.position.1.inverse()),
@@ -263,21 +310,24 @@ fn get_specs<'a>(
         (
             grid.legend.labels.1.as_str(),
             (
-                grid.legend.position.1.get(vp_left, vp_right),
+                grid.legend.position.1.get(vp.left(), vp.right()),
                 grid.legend
                     .position
                     .0
                     .inverse()
-                    .get(vp_top - LABEL_PADDING, vp_bottom + LABEL_PADDING),
+                    .get(vp.top() - LABEL_PADDING, vp.bottom() + LABEL_PADDING),
             ),
             Alignment(
                 HAlignment::Center,
                 get_v_alignment(grid.legend.position.0.inverse()),
             ),
         ),
-    ]);
+    ])
+}
 
-    let zones: Vec<_> = zones
+/// Build the [RectangleSpec]s for the zones
+fn get_zone_specs(zones: &[ZoneConfig]) -> Vec<RectangleSpec> {
+    zones
         .iter()
         .copied()
         .map(
@@ -300,20 +350,7 @@ fn get_specs<'a>(
                 segment_length,
             },
         )
-        .collect();
-
-    MachineSpec {
-        lines,
-        traps,
-        labels: TextSpec {
-            viewport_projection,
-            font_size: grid.legend.font.size,
-            font_family: &grid.legend.font.family,
-            texts,
-            color: grid.legend.font.color,
-        },
-        zones,
-    }
+        .collect()
 }
 
 /// Gets the [VAlignment] based on the passed [VPosition]
@@ -326,4 +363,11 @@ fn get_v_alignment(p: VPosition) -> VAlignment {
 #[inline]
 fn get_h_alignment(p: HPosition) -> HAlignment {
     p.get(HAlignment::Right, HAlignment::Left)
+}
+
+/// Clamps `num` to be in steps of `step`.
+/// Will always round down.
+#[inline]
+fn clamp_to(num: f32, step: f32) -> f32 {
+    num - num % step
 }

--- a/renderer/src/component/machine.rs
+++ b/renderer/src/component/machine.rs
@@ -8,6 +8,7 @@ use wgpu::{Device, Queue, RenderPass};
 
 use crate::{
     buffer_updater::BufferUpdater,
+    component::drawable::Drawable,
     viewport::{Viewport, ViewportProjection, ViewportSource},
 };
 
@@ -86,12 +87,14 @@ impl Machine {
         self.coordinate_legend
             .update_viewport((device, queue), screen_resolution);
     }
+}
 
+impl Drawable for Machine {
     /// Draws this [Machine].
     ///
     /// May overwrite bind groups.
     /// If `REBIND` is `true`, will call the passed `rebind`-function to rebind groups.
-    pub fn draw<const REBIND: bool>(
+    fn draw<const REBIND: bool>(
         &self,
         render_pass: &mut RenderPass<'_>,
         rebind: impl Fn(&mut RenderPass),

--- a/renderer/src/component/machine.rs
+++ b/renderer/src/component/machine.rs
@@ -388,3 +388,85 @@ fn get_h_alignment(p: HPosition) -> HAlignment {
 fn clamp_to(num: f32, step: f32) -> f32 {
     num - num % step
 }
+
+#[cfg(test)]
+mod test {
+    use crate::viewport::ViewportTarget;
+
+    use super::*;
+
+    /// Identity-Viewport, which can be used for testing
+    fn viewport_identity() -> ViewportProjection {
+        ViewportProjection {
+            source: ViewportSource {
+                x: 0.,
+                y: 0.,
+                width: 1.,
+                height: 1.,
+            },
+            target: ViewportTarget {
+                x: 0.,
+                y: 0.,
+                width: 1.,
+                height: 1.,
+            },
+        }
+    }
+
+    /// Sanity-Check: example config should produce plausible results.
+    /// Note: This does not check the exact output of the specs, only plausibility of output counts.
+    #[test]
+    fn example_specs() {
+        let config = Config::example();
+        let viewport_projection = viewport_identity();
+        let mut text_buffer = Vec::new();
+        let specs = get_specs(&config, viewport_projection, &mut text_buffer);
+
+        assert!(!specs.lines.is_empty(), "Did not produce any lines");
+        assert_eq!(
+            specs.traps.len(),
+            config.machine.traps.positions.len(),
+            "Did not produce same number of traps as input"
+        );
+        assert_eq!(
+            specs.zones.len(),
+            config.machine.zones.len(),
+            "Did not produce same number of zones as input"
+        );
+        assert!(
+            specs.labels.texts.into_iter().next().is_some(),
+            "Did not produce any text specs"
+        );
+    }
+
+    /// Sanity-Check: example config with all `display`-options set to `false` should produce plausible results.
+    /// Note: This does not check the exact output of the specs, only plausibility of output counts.
+    #[test]
+    fn example_no_display_specs() {
+        let mut config = Config::example();
+        config.machine.grid.display_ticks = false;
+        config.machine.grid.legend.display_labels = false;
+        config.machine.grid.legend.display_numbers = false;
+        config.time.display = false;
+
+        let viewport_projection = viewport_identity();
+        let mut text_buffer = Vec::new();
+        let specs = get_specs(&config, viewport_projection, &mut text_buffer);
+
+        assert!(specs.lines.is_empty(), "Should not produce any lines");
+        assert_eq!(
+            specs.traps.len(),
+            config.machine.traps.positions.len(),
+            "Did not produce same number of traps as input"
+        );
+        assert_eq!(
+            specs.zones.len(),
+            config.machine.zones.len(),
+            "Did not produce same number of zones as input"
+        );
+        assert!(
+            specs.labels.texts.into_iter().next().is_none(),
+            "Should not produce any text specs"
+        );
+    }
+}

--- a/renderer/src/component/machine.rs
+++ b/renderer/src/component/machine.rs
@@ -198,6 +198,11 @@ fn get_specs<'a>(
 /// Create the [LineSpec]s for the grid fit to the [ViewportSource].
 #[inline]
 fn get_grid_lines_specs(grid: &GridConfig, vp: ViewportSource) -> Vec<LineSpec> {
+    if !grid.display_ticks {
+        // Don't display any ticks
+        return Vec::new();
+    }
+
     // The viewport-edges clamped to the grid/legend steps
     let vp_left_grid = clamp_to(vp.left(), grid.step.0);
     let vp_top_grid = clamp_to(vp.top(), grid.step.1);
@@ -245,6 +250,12 @@ fn build_number_labels(
     text_buffer: &mut Vec<(String, (f32, f32), Alignment)>,
     vp: ViewportSource,
 ) {
+    if !grid.legend.display_numbers {
+        // Don't display number labels
+        *text_buffer = Vec::new();
+        return;
+    }
+
     // The viewport-edges clamped to the grid/legend steps
     let vp_left_legend = clamp_to(vp.left(), grid.legend.step.0);
     let vp_top_legend = clamp_to(vp.top(), grid.legend.step.1);
@@ -289,6 +300,12 @@ fn add_grid_legend<'a>(
     texts: impl IntoIterator<Item = (&'a str, (f32, f32), Alignment)>,
 ) -> impl Iterator<Item = (&'a str, (f32, f32), Alignment)> {
     let texts = texts.into_iter();
+
+    if !grid.legend.display_labels {
+        // Don't display any labels
+        // Still need to chain (empty) vector to produce same output type
+        return texts.chain(Vec::new());
+    }
 
     // Add axis labels
     texts.chain(vec![

--- a/renderer/src/component/time.rs
+++ b/renderer/src/component/time.rs
@@ -1,7 +1,9 @@
 use naviz_state::{config::Config, state::State};
 use wgpu::{Device, Queue, RenderPass};
 
-use crate::{buffer_updater::BufferUpdater, viewport::ViewportProjection};
+use crate::{
+    buffer_updater::BufferUpdater, component::drawable::Drawable, viewport::ViewportProjection,
+};
 
 use super::{
     primitive::text::{Alignment, HAlignment, Text, TextSpec, VAlignment},
@@ -51,13 +53,15 @@ impl Time {
         self.text
             .update_viewport((device, queue), screen_resolution);
     }
+}
 
+impl Drawable for Time {
     /// Draws this [Time].
     ///
     /// May overwrite bind groups.
     /// If `REBIND` is `true`, will call the passed `rebind`-function to rebind groups.
     #[inline]
-    pub fn draw<const REBIND: bool>(
+    fn draw<const REBIND: bool>(
         &self,
         render_pass: &mut RenderPass<'_>,
         rebind: impl Fn(&mut RenderPass),

--- a/renderer/src/renderer.rs
+++ b/renderer/src/renderer.rs
@@ -4,8 +4,8 @@ use wgpu::{Device, Queue, RenderPass, TextureFormat};
 use crate::{
     buffer_updater::BufferUpdater,
     component::{
-        atoms::Atoms, legend::Legend, machine::Machine, time::Time, updatable::Updatable,
-        ComponentInit,
+        atoms::Atoms, drawable::Drawable, legend::Legend, machine::Machine, time::Time,
+        updatable::Updatable, ComponentInit,
     },
     globals::Globals,
     layout::Layout,

--- a/renderer/src/renderer.rs
+++ b/renderer/src/renderer.rs
@@ -220,3 +220,42 @@ fn get_layout(config: &Config, screen_resolution: (u32, u32)) -> Layout {
         )
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn example_layout_has_all_sections() {
+        let config = Config::example();
+
+        let layout = get_layout(&config, (1920, 1080));
+
+        assert!(
+            layout.legend.is_some(),
+            "Example config should produce a layout with space for the legend"
+        );
+        assert!(
+            layout.time.is_some(),
+            "Example config should produce a layout with space for the time"
+        );
+    }
+
+    #[test]
+    fn example_layout_display_none_only_content() {
+        let mut config = Config::example();
+        config.legend.entries = Vec::new(); // No legend
+        config.time.display = false; // No time
+
+        let layout = get_layout(&config, (1920, 1080));
+
+        assert!(
+            layout.legend.is_none(),
+            "Example config without legend and time should not allocates space for legend"
+        );
+        assert!(
+            layout.time.is_none(),
+            "Example config without legend and time should not allocates space for time"
+        );
+    }
+}

--- a/renderer/src/viewport.rs
+++ b/renderer/src/viewport.rs
@@ -39,6 +39,27 @@ pub struct ViewportTarget {
     pub height: f32,
 }
 
+impl ViewportProjection {
+    /// An identity-[ViewportProjection].
+    /// Transforms nothing and fills the whole viewport.
+    pub fn identity() -> Self {
+        Self {
+            source: ViewportSource {
+                x: -1.,
+                y: -1.,
+                width: 2.,
+                height: 2.,
+            },
+            target: ViewportTarget {
+                x: -1.,
+                y: -1.,
+                width: 2.,
+                height: 2.,
+            },
+        }
+    }
+}
+
 impl From<ViewportProjection> for Mat4 {
     fn from(ViewportProjection { source, target }: ViewportProjection) -> Self {
         // Content -> Between

--- a/repository/src/lib.rs
+++ b/repository/src/lib.rs
@@ -229,11 +229,10 @@ impl Repository {
     }
 
     /// The list of entries of this repository: `(id, name, removable)`-pairs
-    pub fn list(&self) -> Vec<(&str, &str, bool)> {
+    pub fn list(&self) -> impl Iterator<Item = (&str, &str, bool)> {
         self.0
             .iter()
             .map(|(id, entry)| (id.as_str(), entry.name(), entry.source.is_removable()))
-            .collect()
     }
 
     /// Checks whether the repository has an entry with `id`
@@ -480,7 +479,7 @@ mod tests {
         // Check if correct number of configs was imported
         assert_eq!(
             configs.len(),
-            repo.list().len(),
+            repo.list().count(),
             "Wrong number of files imported in repo"
         );
 
@@ -497,8 +496,8 @@ mod tests {
         let repo_new = Repository::empty()
             .load_user_dir(subdir)
             .expect("Failed to load configs from disk");
-        let mut list_old = repo.list();
-        let mut list_new = repo_new.list();
+        let mut list_old: Vec<_> = repo.list().collect();
+        let mut list_new: Vec<_> = repo_new.list().collect();
         list_old.sort();
         list_new.sort();
         assert_eq!(
@@ -530,7 +529,6 @@ mod tests {
 
         let list: Vec<_> = repo
             .list()
-            .into_iter()
             .map(|(id, _name, removable)| (id.to_owned(), removable))
             .collect();
 
@@ -593,9 +591,7 @@ mod tests {
         }
 
         assert!(
-            repo.list()
-                .into_iter()
-                .all(|(_id, _name, removable)| removable),
+            repo.list().all(|(_id, _name, removable)| removable),
             "Imported configs not marked as removable"
         );
 

--- a/state/src/config.rs
+++ b/state/src/config.rs
@@ -33,6 +33,8 @@ pub struct GridConfig {
     pub line: LineConfig,
     /// The config for the legend at the sides
     pub legend: GridLegendConfig,
+    /// Whether to display the coordinate ticks
+    pub display_ticks: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -45,6 +47,10 @@ pub struct GridLegendConfig {
     pub labels: (String, String),
     /// The position of the labels
     pub position: (VPosition, HPosition),
+    /// Whether to display the labels for the x- and y-axis
+    pub display_labels: bool,
+    /// Whether to display the numbers on the axes
+    pub display_numbers: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -118,6 +124,8 @@ pub struct LegendEntry {
 pub struct TimeConfig {
     /// The config for the font of the time-display
     pub font: FontConfig,
+    /// Whether to display the current time
+    pub display: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -210,6 +218,7 @@ impl Config {
                         duty: 1.,
                         color: [127, 127, 127, 255],
                     },
+                    display_ticks: true,
                     legend: GridLegendConfig {
                         step: (40., 40.),
                         font: FontConfig {
@@ -219,6 +228,8 @@ impl Config {
                         },
                         labels: ("x".to_owned(), "y".to_owned()),
                         position: (VPosition::Bottom, HPosition::Left),
+                        display_labels: true,
+                        display_numbers: true,
                     },
                 },
                 traps: TrapConfig {
@@ -332,6 +343,7 @@ impl Config {
                     color: [0, 0, 0, 255],
                     family: "Fira Mono".to_owned(),
                 },
+                display: true,
             },
             content_extent: ((0., 0.), (100., 120.)),
         }

--- a/state/src/config.rs
+++ b/state/src/config.rs
@@ -206,6 +206,16 @@ impl HPosition {
 }
 
 impl Config {
+    /// Whether the time-area should be displayed
+    pub fn display_time(&self) -> bool {
+        self.time.display
+    }
+
+    /// Whether the sidebar should be displayed
+    pub fn display_sidebar(&self) -> bool {
+        !self.legend.entries.is_empty()
+    }
+
     /// An example [Config]
     pub fn example() -> Self {
         Self {


### PR DESCRIPTION
## Description

Added a button to the menu which allows forcing the new zen-mode of #114 independent of the selected style.
Uses the refactored architecture of #116.

Fixes #88

**This PR depends on the changes in #116 ([new changes](https://github.com/cda-tum/mqt-naviz/compare/refactor/menu-app-state...feat/88-zen-button)).**

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [X] The changes follow the project's style guidelines and introduce no new warnings.
- [X] The changes are fully tested and pass the CI checks.
- [X] I have reviewed my own code changes.
